### PR TITLE
Update scraper URL to new scraper

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -9,6 +9,6 @@ mn_names = EveryPolitician::Wikidata.wikipedia_xpath(
   xpath: '//table[@class="navbox"]//table//tr[td]//td[1]//a[not(@class="new")]/@title',
 ) 
 
-en_names = EveryPolitician::Wikidata.morph_wikinames(source: 'tmtmtmtm/mongolia-khurai-wp', column: 'wikiname')
+en_names = EveryPolitician::Wikidata.morph_wikinames(source: 'everypolitician-scrapers/mongolia-khurai-wp-multiple-terms', column: 'wikiname')
 
 EveryPolitician::Wikidata.scrape_wikidata(names: { mn: mn_names, en: en_names })


### PR DESCRIPTION
This scraper uses the membership scraper as a source of wikinames.

The membership scraper has been updated to scrape members for terms: 2008, 2012
and 2016. We are updating the URL to point to its new morph home.